### PR TITLE
Forms are no longer duplicated on plugin activation

### DIFF
--- a/includes/class-aria-create-competition.php
+++ b/includes/class-aria-create-competition.php
@@ -45,10 +45,8 @@ class ARIA_Create_Competition {
     $form_id = ARIA_API::aria_get_create_competition_form_id();
     if ($form_id === -1) {
       $form_id = self::aria_create_competition_form();
+      ARIA_API::aria_publish_form(CREATE_COMPETITION_FORM_NAME, $form_id, CHAIRMAN_PASS);
     }
-
-    // publish the new form
-    ARIA_API::aria_publish_form(CREATE_COMPETITION_FORM_NAME, $form_id, CHAIRMAN_PASS);
   }
 
   /**

--- a/includes/class-aria-music.php
+++ b/includes/class-aria-music.php
@@ -110,6 +110,11 @@ class ARIA_Music {
    * @since 1.0.0
    */
   public static function aria_create_music_upload_form() {
+    // don't create form if it already exists
+    if (ARIA_API::aria_get_song_upload_form_id() !== -1) {
+      return; 
+    }
+
     $form_name = MUSIC_UPLOAD_FORM_NAME;
     $form = new GF_FORM($form_name, "");
 


### PR DESCRIPTION
Can now activate/deactivate plugin and the three main forms (create competition, music upload, and scheduling) are no longer created again. 